### PR TITLE
Eliminación de teléfono del widget de whatsapp

### DIFF
--- a/frontend/src/components/Page/Layout/index.jsx
+++ b/frontend/src/components/Page/Layout/index.jsx
@@ -32,7 +32,7 @@ export function Layout({ children, image, title }) {
         <div className='dark:text-black z-50 absolute'>
         <WhatsAppWidget
           CompanyIcon={ClubIconSVG}
-          phoneNumber="584149056161"
+          phoneNumber=""
           companyName="Club Agronomía Central"
           replyTimeText="Usualmente responde en un día"
           message="¡Hola! ¿Cómo puedo ayudarte?"


### PR DESCRIPTION
Frontend > Components > Page > Layout.jsx

El número telefónico era mío personal y me estaban escribiendo argentinos para apartar canchas jajaja Se puede agregar el del club si se tiene.